### PR TITLE
Embed document metadata

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -45,7 +45,7 @@
   // Content containing list of authors
   authors: [],
 
-  date: datetime.today().display(),
+  date: datetime.today(),
 
   // The article's paper size. Also affects the margins.
   paper-size: "us-letter",
@@ -53,6 +53,20 @@
   // The paper's content.
   body,
 ) = {
+  set document(
+    title: title,
+    author: authors.text,
+    date: if type(date) == datetime {
+      date
+    } else {
+      none
+    },
+  )
+  // Convert datetime to formatted date
+  if type(date) == datetime {
+    date = date.display()
+  }
+
   set page(
     numbering: "1",
     number-align: center,

--- a/typst.toml
+++ b/typst.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bamdone-rebuttal"
-version = "0.1.2"
+version = "0.1.3"
 entrypoint = "lib.typ"
 license = "MIT-0"
 description = "Rebuttal/response letter template that allows authors to respond to feedback given by reviewers in a peer-review process on a point-by-point basis."


### PR DESCRIPTION
This should be backwards compatible for users setting the date as a string (rather than a `datetime` object), in which case the date is not embedded using `#set document()`.